### PR TITLE
Fixed issue where browser would always close on its own.

### DIFF
--- a/libraries/common.robot
+++ b/libraries/common.robot
@@ -28,7 +28,7 @@ Login As Admin
     Input Text                          //*[@name="username"]           ${ADMIN_USERNAME}
     Input Text                          //*[@name="password"]           ${ADMIN_PASSWORD}
     Click Element                       //*[@value="Log In"]
-    Wait Until Element Is Visible       //h1[.="Accounts Overview"]
+    Wait Until Element Is Visible       //h1[.="Accounts Overview"]     error=Login failed... Server may not be responding
 
 Logout
     Wait Until Element Is Visible       //a[.="Log Out"]

--- a/libraries/webDriver.py
+++ b/libraries/webDriver.py
@@ -4,6 +4,7 @@ from selenium import webdriver
 def create_chrome_options():
     options = webdriver.ChromeOptions()
     options.add_experimental_option("excludeSwitches", ["enable-automation"])
+    options.add_experimental_option('detach', True)
     options.add_experimental_option('prefs', {"credentials_enable_service": False,
                                               'profile': {'password_manager_enabled': False}})
     # options.add_experimental_option("detach", True)

--- a/suites/regression_PARA.robot
+++ b/suites/regression_PARA.robot
@@ -3,7 +3,7 @@ Library             SeleniumLibrary
 Resource            ../libraries/common.robot
 
 Suite Setup         PARA Setup
-#Suite Teardown      Close All Browsers
+Suite Teardown      Close All Browsers
 
 # Test Setup          Go To Parabank Login Page
 # Test Teardown       Logout

--- a/suites/regression_TEST.robot
+++ b/suites/regression_TEST.robot
@@ -3,7 +3,7 @@ Library             SeleniumLibrary
 Resource            ../libraries/common.robot
 
 Suite Setup         TEST Setup
-#Suite Teardown      Close All Browsers
+Suite Teardown      Close All Browsers
 
 #Test Setup          Go To Parabank Login Page
 #Test Teardown       Logout


### PR DESCRIPTION
- **common.robot**: Added error message to potential login failure.. ParaBank server is not responding at the moment. Not being able to login with the default name/pass is a warning sign to this now.

- **webDriver.py**: Added chrome option to not close browser automatically (this was because the Python function recognized the script as completed, thus closed the process down after - which is not what we want).

- **regression_PARA.robot**: Uncommented out "Suite Teardown" - works as expected now

- **regression_TEST.robot**: Uncommented out "Suite Teardown" - works as expected now