### PR TITLE
Completed the flow of opening new account from permanent account 13344

### DIFF
--- a/suites/regression_PARA.robot
+++ b/suites/regression_PARA.robot
@@ -22,15 +22,17 @@ TC-PARA-002 Login and Logout of ParaBank
     Logout
     log to console      \nLogged out successfully.\n
 
-TC-PARA-003
-    #// This testcase is testing the flow for opening new accounts.
+TC-PARA-003 Open a New Account from Main Existing Account
+    #// This testcase is testing the flow for opening new accounts, provided that we use the permanent account 13344.
     Login As Admin
-
-    ${accountType}=         Set Variable        SAVINGS
-    ${existingAccount}=     Get Existing Account with More Than $100
-    Go To Page      Open New Account
-    #Open New Account        ${accountType}      ${existingAccount}
-
+    ${accountType}=         Set Variable            SAVINGS
+    ${existingAccount}=     Set Variable            13344
+    Verify Existing Account Has More Than $100      ${existingAccount}     #// 13344 is always the value of the main account
+    Go To Page              Open New Account
+    ${newAccountId}         ${newAccountURL}=       Open New Account        ${accountType}      ${existingAccount}
+    Log To Console          \n\nNew Account ID: ${newAccountId}
+    Log To Console          \n\nNew Account URL: ${newAccountURL}
+    Go To                    ${newAccountURL}
 
 *** Keywords ***
 PARA Setup


### PR DESCRIPTION
- **common.robot**: Fixed typo in the Go To Page keyword. Fixed mistake in Go To Accounts Overview Page - now assumes there will always be one existing account instead of two. Fixed incorrect syntax for Get Element Attribute. Changed purpose of keyword "Get Existing Account with More Than $100" - now verifies the provided account has more than $100. Added String library. Completed Table_Get Row Index.

- **regression_PARA.robot**: Completed hardcoded version of PARA-003 (always using permanent account 13344)